### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: chmod +x gradlew
       
       - name: Create a Release
-        uses: elgohr/Github-Release-Action@master
+        uses: elgohr/Github-Release-Action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITTOKEN }}
         with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore